### PR TITLE
feat: rewrite chittymonitor as CF Worker with Agents SDK

### DIFF
--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -1,6 +1,5 @@
 export interface Env {
   MONITOR_AGENT: DurableObjectNamespace;
-  MONITOR_CACHE: KVNamespace;
-  SERVICE_NAME: string;
+SERVICE_NAME: string;
   CHITTY_AUTH_SERVICE_TOKEN?: string;
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -19,10 +19,6 @@
     }
   ],
 
-  "kv_namespaces": [
-    { "binding": "MONITOR_CACHE", "id": "" }
-  ],
-
   "triggers": {
     "crons": ["*/5 * * * *"]
   },

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -6,6 +6,10 @@
   "account_id": "0bc21e3a5a9de1a4cc843be9c3e98121",
   "workers_dev": false,
 
+  "routes": [
+    { "pattern": "monitor.chitty.cc/*", "zone_name": "chitty.cc" }
+  ],
+
   "durable_objects": {
     "bindings": [
       { "name": "MONITOR_AGENT", "class_name": "MonitorAgent" }
@@ -27,13 +31,5 @@
 
   "vars": {
     "SERVICE_NAME": "chittymonitor"
-  },
-
-  "env": {
-    "production": {
-      "routes": [
-        { "pattern": "monitor.chitty.cc/*", "zone_name": "chitty.cc" }
-      ]
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Rewrites chittymonitor from Replit Express app to Cloudflare Worker using Agents SDK with Durable Objects
- MonitorAgent singleton handles health sweeps, app tracking, package management, CI workflow tracking
- Fixes wrangler env inheritance bug — `env.production` block was dropping DO bindings, vars, and tail consumers
- Already deployed and healthy at `monitor.chitty.cc`

## Test plan
- [x] `wrangler deploy --dry-run` shows correct bindings (MONITOR_AGENT DO, SERVICE_NAME var, chittytrack tail)
- [x] Deployed to production — `curl https://monitor.chitty.cc/health` returns 200
- [x] Cron trigger configured (`*/5 * * * *`) for automated health sweeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)