### PR TITLE
Add branded README with ecosystem badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+![ChittyOS](https://img.shields.io/badge/ChittyOS-service-6366F1?style=flat-square)
+![Tier](https://img.shields.io/badge/tier-3%20operational-3730A3?style=flat-square)
+
+# ChittyMonitor
+
+> Application monitoring and tracking dashboard for the ChittyOS ecosystem.
+
+ChittyMonitor provides real-time monitoring of connected applications across platforms (Replit, GitHub, Vercel), tracking status, performance metrics, workflow pipelines, and activity events. It features a React frontend with live-refreshing metrics, an Express.js backend, and Neon PostgreSQL for storing app registrations, heartbeats, package operations, and CI/CD workflow runs. Integrates with ChittyID for authentication, ChittyFlow for pipeline tracking, and ChittyIntel for AI-powered anomaly detection.
+
+**Domain**: `monitor.chitty.cc`

--- a/package.json
+++ b/package.json
@@ -102,5 +102,6 @@
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
-  }
+  },
+  "description": "ChittyOS application monitoring and health dashboard"
 }


### PR DESCRIPTION
## Summary
- Adds branded header badges (org, tier, deploy target) to README
- Updates service description to accurately reflect what this service does

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)